### PR TITLE
Fix: Se mueve la lógica de guardado de eventos al service

### DIFF
--- a/src/controllers/googleCalendarController.ts
+++ b/src/controllers/googleCalendarController.ts
@@ -1,7 +1,6 @@
 import { Response } from 'express';
 import googleCalendarService from '../services/googleCalendarService';
 import { hasValidTokens } from '../config/googleCalendar';
-import Event from '../models/event';
 import { AuthRequest } from "../middleware/auth";
 
 const googleCalendarController = {
@@ -30,33 +29,13 @@ const googleCalendarController = {
         new Date(now.getTime() + 30 * 24 * 60 * 60 * 1000).toISOString()
       );
 
-      const events = await googleCalendarService.getEvents(
-        calendarId,
-        timeMin,
-        timeMax
-      );
+
+      const events = await googleCalendarService.getEvents(calendarId, timeMin, timeMax);
+
       // Guarda en BD si se solicita con ?save=true
       if (req.query.save === 'true' && events) {
-        const userId = req.user?.id
-          ? String(req.user.id)
-          : '1'; // fallback por si no se envía usuario
-
-        for (const event of events) {
-          await Event.upsert({
-            googleEventId: event.id!,
-            title: event.summary || 'Sin título',
-            startTime: new Date(
-              event.start?.dateTime || (event.start?.date as string)
-            ),
-            endTime: new Date(
-              event.end?.dateTime || (event.end?.date as string)
-            ),
-            roomEmail: calendarId,
-            userId,
-            attendees: JSON.stringify(event.attendees || []),
-          });
-        }
-        console.log(`💾 ${events.length} eventos guardados en BD`);
+        const userId = req.user?.id ? String(req.user.id) : '1';
+        await googleCalendarService.saveEvents(events, userId, calendarId);
       }
 
       res.json({
@@ -75,4 +54,4 @@ const googleCalendarController = {
 };
 
 
-  export default googleCalendarController;
+export default googleCalendarController;

--- a/src/services/googleCalendarService.ts
+++ b/src/services/googleCalendarService.ts
@@ -1,8 +1,9 @@
 import { calendar, oauth2Client } from "../config/googleCalendar";
+import Event from "../models/event";
 
 
 class GoogleCalendarService {
-    
+
     /**
       * Obtiene los eventos de un calendario de Google.
       * @param calendarId  ID del calendario (ej "primary")
@@ -63,6 +64,23 @@ class GoogleCalendarService {
             throw error;
         }
     }
+    async saveEvents(events: any[], userId: string, calendarId: string) {
+        for (const event of events) {
+            await Event.upsert({
+                googleEventId: event.id!,
+                title: event.summary || 'Sin título',
+                startTime: new Date(event.start?.dateTime || (event.start?.date as string)),
+                endTime: new Date(event.end?.dateTime || (event.end?.date as string)),
+                roomEmail: calendarId,
+                userId,
+                attendees: JSON.stringify(event.attendees || []),
+            });
+        }
+        console.log(` ${events.length} eventos guardados en BD`);
+    }
+
+
+
 }
 
 export default new GoogleCalendarService();


### PR DESCRIPTION
Se realiza los siguientes cambios en el PR:

Se refactoriza el controller de Google Calendar para delegar la lógica de guardado de eventos en el Service.
Implementa el método "saveEvents"  mediante sequelize   para insertar o actualizar eventos
Solamente el controller se encarga de la gestion de request como deberia de haber sido y no logica de negocio.

Anteriormente ,el controller estaba encargado de:
-Obtener los eventos desde Google Calendar.
-Iterar sobre los eventos y guardarlos directamente en la base de datos.
-Procesar y transformar los datos antes de guardarlos

esta refactorización corrige el bug y sigue mejores prácticas