### PR TITLE
cambios para implementacion de forecast

### DIFF
--- a/src/controllers/forecastController.ts
+++ b/src/controllers/forecastController.ts
@@ -1,0 +1,26 @@
+import { Request, Response } from "express";
+import ForecastService from "../services/forecastService";
+
+class ForecastController {
+    async fetchForecast(req: Request, res: Response): Promise<void> {
+        try {
+            const { roomEmail } = req.query;
+
+            const forecasts = await ForecastService.getForecastsForRooms(
+                roomEmail as string | undefined
+            );
+
+            res.status(200).json({
+                success: true,
+                data: forecasts,
+            });
+        } catch (error: any) {
+            res.status(500).json({
+                success: false,
+                message: error.message || "Error al obtener pronósticos",
+            });
+        }
+    }
+}
+
+export default new ForecastController();

--- a/src/dtos/forecastDTO.ts
+++ b/src/dtos/forecastDTO.ts
@@ -1,0 +1,12 @@
+export interface ForecastDTO {
+    roomEmail: string
+    date: Date
+    occupancyPredicted: number
+    lower: number
+    upper: number
+}
+
+export interface RoomForecastDTO {
+    roomEmail: string
+    forecasts: ForecastDTO[]
+}

--- a/src/models/assoc.ts
+++ b/src/models/assoc.ts
@@ -1,6 +1,7 @@
 import { Room } from "./room";
 import { Event } from "./event";
 import { formatModelLog } from "../utils/dateUtils";
+import { Forecast } from "./forecast";
 
 export function asociacionesModelos() {
 
@@ -20,6 +21,18 @@ export function asociacionesModelos() {
         foreignKey: 'current_event',
         targetKey: 'id',
         as: 'currentEvent'
+    });
+
+    Room.hasMany(Forecast, {
+        foreignKey: 'roomEmail',
+        sourceKey: 'email',
+        as: 'forecasts'
+    });
+
+    Forecast.belongsTo(Room, {
+        foreignKey: 'roomEmail',
+        targetKey: 'email',
+        as: 'room'
     });
 
     console.log(formatModelLog('Relaciones entre modelos inicializadas.'));

--- a/src/models/forecast.ts
+++ b/src/models/forecast.ts
@@ -1,0 +1,55 @@
+import { Model, DataTypes, Optional } from "sequelize";
+import { ForecastAttributes } from "./forecast.types";
+import sequelize from "../config/database";
+
+interface ForecastCreationAttributes extends Optional<ForecastAttributes, never> { }
+
+export class Forecast extends Model<ForecastAttributes, ForecastCreationAttributes> implements ForecastAttributes {
+    public id!: number;
+    public roomEmail!: string;
+    public date!: Date;
+    public occupancyPredicted!: number;
+    public lower!: number;
+    public upper!: number;
+    public readonly createdAt!: Date;
+}
+
+Forecast.init(
+    {
+        id: {
+            type: DataTypes.INTEGER,
+            allowNull: false,
+            unique: true
+        },
+        roomEmail: {
+            type: DataTypes.STRING,
+            allowNull: false,
+        },
+        date: {
+            type: DataTypes.DATE,
+            allowNull: false,
+        }, 
+        occupancyPredicted: {
+            type: DataTypes.FLOAT,
+            allowNull: false,
+        },
+        lower: {
+            type: DataTypes.FLOAT,
+            allowNull: false,
+        },
+        upper: {
+            type: DataTypes.FLOAT,
+            allowNull: false,
+        }
+    },
+    {
+        sequelize,
+        tableName: "room_forecasts",
+        timestamps: true,
+        paranoid: true,
+        modelName: "Forecast",
+        indexes: [
+            { fields: ['roomEmail'] }
+        ]
+    }
+)

--- a/src/models/forecast.types.ts
+++ b/src/models/forecast.types.ts
@@ -1,0 +1,8 @@
+export interface ForecastAttributes {
+    id: number;
+    roomEmail: string;
+    date: Date;
+    occupancyPredicted: number;
+    lower: number;
+    upper: number;
+}

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,8 +1,9 @@
 import { Room } from "./room";
 import { Event } from "./event";
 import { User } from "./user";
+import { Forecast } from "./forecast"
 import { asociacionesModelos } from "./assoc";
 
 asociacionesModelos();
 
-export { Room, Event, User };
+export { Room, Event, User, Forecast };

--- a/src/routes/forecastRoutes.ts
+++ b/src/routes/forecastRoutes.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import ForecastController from "../controllers/forecastController";
+import { authenticate } from "../middleware/auth";
+
+const router = Router();
+router.get('/fetch', authenticate, ForecastController.fetchForecast);
+
+export default router;

--- a/src/services/forecastService.ts
+++ b/src/services/forecastService.ts
@@ -1,0 +1,91 @@
+import { ForecastDTO, RoomForecastDTO } from "../dtos/forecastDTO";
+import { Forecast } from "../models";
+
+import { Op } from "sequelize";
+
+class ForecastService {
+    /**
+     * Obtiene las predicciones de ocupación para las salas.
+     * Si se proporciona un email de sala, filtra las predicciones para esa sala específica.
+     * De lo contrario, devuelve las predicciones para todas las salas.
+     *
+     * @param roomEmail - (Opcional) El email de la sala para filtrar las predicciones, trayendo así solo las de esa sala.
+     * @return Una promesa que resuelve a una lista de objetos RoomForecastDTO, cada uno conteniendo el email de la sala y una lista de predicciones asociadas (cada elemento de la lista es un ForecastDTO).
+     * 
+     * @example
+     * Respuesta de ejemplo:
+     * [
+     *   {
+     *     roomEmail: "mail@delasala.com",
+     *     forecasts: [
+     *       {
+     *         roomEmail: "sala-a@company.com",
+     *         date: "2025-11-18T00:00:00.000Z",
+     *         occupancyPredicted: 0.65,
+     *         lower: 0.50,
+     *         upper: 0.80
+     *       },
+     *       {
+     *         roomEmail: "sala-a@company.com",
+     *         date: "2025-11-19T00:00:00.000Z",
+     *         occupancyPredicted: 0.72,
+     *         lower: 0.58,
+     *         upper: 0.86
+     *       }
+     *     ]
+     *   },
+     *   {
+     *     roomEmail: "sala-b@company.com",
+     *     forecasts: [
+     *       {
+     *         roomEmail: "sala-b@company.com",
+     *         date: "2025-11-18T00:00:00.000Z",
+     *         occupancyPredicted: 0.45,
+     *         lower: 0.30,
+     *         upper: 0.60
+     *       }
+     *     ]
+     *   }
+     * ]
+     */
+    async getForecastsForRooms(roomEmail?: string): Promise<RoomForecastDTO[]> {
+        const whereClause: any = {};
+
+        if (roomEmail) {
+            whereClause.roomEmail = roomEmail;
+        }
+
+        const forecasts = await Forecast.findAll({
+            where: whereClause,
+            order: [['roomEmail', 'ASC'], ['date', 'ASC']],
+        });
+
+        const grouped = new Map<string, ForecastDTO[]>();
+
+        forecasts.forEach((forecast) => {
+            const record: ForecastDTO = {
+                roomEmail: forecast.roomEmail,
+                date: forecast.date,
+                occupancyPredicted: forecast.occupancyPredicted,
+                lower: forecast.lower,
+                upper: forecast.upper,
+            };
+
+            if (!grouped.has(forecast.roomEmail)) {
+                grouped.set(forecast.roomEmail, []);
+            }
+            grouped.get(forecast.roomEmail)!.push(record);
+        });
+
+        const result: RoomForecastDTO[] = Array.from(grouped.entries()).map(
+            ([email, forecasts]) => ({
+                roomEmail: email,
+                forecasts,
+            })
+        );
+
+        return result;
+    }
+}
+
+export default new ForecastService();


### PR DESCRIPTION
Este pull request adjunta cambios relacionados a la implementación del modelo de predicciones del heatmap. 
El modelo de predicción, en inglés "forecast".

Adjuntamos cambios para:

- Rutas
- Modelo de base de datos
- DTOs para manipular los datos y enviarlos al frontend
- Controller y service
- Relaciones de entidades

El service adjunta una función la cual parsea la información obtenida y la convierte a un DTO, el cual contiene el mail de la sala como clave y otro DTO que adjunta registros como array de predicciones.

Estos cambios sirven para poder enviar al frontend la información que genere Prophet (script aparte de Python).